### PR TITLE
10秒クリックチャレンジの追加 / 連打時のタイマー修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,16 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
     <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <Link
+          href="/practice/click-challenge"
+          className="text-blue-600 underline text-lg"
+        >
+          10秒クリックチャレンジ（スコア制）
+        </Link>
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/src/app/practice/click-challenge/page.tsx
+++ b/src/app/practice/click-challenge/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const DURATION = 10_000; // ms
+
+export default function ClickChallenge() {
+  const [timeLeft, setTimeLeft] = useState(DURATION / 1000);
+  const [score, setScore] = useState(0);
+  const [bestScore, setBestScore] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  const startedAt = useRef(0);
+  const frameRef = useRef<number>();
+  const scoreRef = useRef(0);
+  const bestScoreRef = useRef(0);
+
+  // Load best score from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem('click-challenge-best');
+    if (stored) {
+      const val = Number(stored);
+      setBestScore(val);
+      bestScoreRef.current = val;
+    }
+  }, []);
+
+  // Timer effect based on time difference
+  useEffect(() => {
+    if (!running) return;
+    startedAt.current = performance.now();
+
+    const tick = () => {
+      const now = performance.now();
+      const remaining = Math.max(0, DURATION - (now - startedAt.current));
+      setTimeLeft(remaining / 1000);
+
+      if (remaining <= 0) {
+        setRunning(false);
+        const finalScore = scoreRef.current;
+        if (finalScore > bestScoreRef.current) {
+          bestScoreRef.current = finalScore;
+          setBestScore(finalScore);
+          localStorage.setItem('click-challenge-best', String(finalScore));
+        }
+        return;
+      }
+
+      frameRef.current = requestAnimationFrame(tick);
+    };
+
+    frameRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    };
+  }, [running]);
+
+  const startGame = () => {
+    setScore(0);
+    scoreRef.current = 0;
+    setTimeLeft(DURATION / 1000);
+    setRunning(true);
+  };
+
+  const handleClick = () => {
+    if (running && timeLeft > 0) {
+      setScore((s) => {
+        const val = s + 1;
+        scoreRef.current = val;
+        return val;
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-10">
+      <div className="text-6xl font-bold">{timeLeft.toFixed(1)}s</div>
+      <div className="text-4xl">Score: {score}</div>
+      <div className="text-2xl">Best: {bestScore}</div>
+      {running ? (
+        <button
+          onClick={handleClick}
+          className="w-48 h-48 rounded-full bg-blue-500 text-white text-3xl flex items-center justify-center"
+        >
+          TAP!
+        </button>
+      ) : (
+        <button
+          onClick={startGame}
+          className="w-48 h-48 rounded-full bg-green-500 text-white text-3xl flex items-center justify-center"
+        >
+          START
+        </button>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## 目的
- クリック練習の「10秒チャレンジ」を追加し、トップから遷移できるようにする。
- 連打時に残り時間が減らない不具合を修正する。

## 変更点
- `/practice/click-challenge` を追加（スコア・残り時間・自己ベスト）
- トップ（`/`）に遷移リンクを追加
- タイマーを時刻差分ベースに変更（連打中でも等速で 10±0.2 秒で終了）

## 動作確認
1. `npm i && npm run dev`
2. `/` → リンクから `/practice/click-challenge` へ
3. 「スタート」→ 連打しても等速で 10±0.2 秒で終了
4. 終了後はスコアが加算されない／自己ベストが保持される

## 関連Issue
Closes #1  
Fixes #2