### PR TITLE
feat: add double click practice page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,12 @@ export default function Home() {
         >
           10秒クリックチャレンジ（スコア制）
         </Link>
+        <Link
+          href="/practice/double-click"
+          className="rounded border border-blue-600 px-4 py-2 text-blue-600 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          ダブルクリック練習へ
+        </Link>
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/src/app/practice/double-click/page.tsx
+++ b/src/app/practice/double-click/page.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Difficulty = 'easy' | 'normal' | 'hard';
+
+const DIFFICULTIES: Record<Difficulty, { label: string; interval: number; size: number }> = {
+  easy: { label: 'やさしい', interval: 600, size: 80 },
+  normal: { label: 'ふつう', interval: 450, size: 56 },
+  hard: { label: 'むずかしい', interval: 300, size: 40 },
+};
+
+export default function DoubleClickPractice() {
+  const [difficulty, setDifficulty] = useState<Difficulty>('easy');
+  const [status, setStatus] = useState<'idle' | 'success' | 'failure'>('idle');
+  const [last, setLast] = useState<number | null>(null);
+  const [best, setBest] = useState<number | null>(null);
+  const [combo, setCombo] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const firstTimeRef = useRef(0);
+  const phaseRef = useRef<'idle' | 'waitingSecond' | 'waitingThird'>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setIsMobile(/Mobi|Android/i.test(navigator.userAgent));
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!targetRef.current) return;
+      if (targetRef.current.contains(e.target as Node)) return;
+      if (phaseRef.current !== 'idle') {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        setStatus('failure');
+        setCombo(0);
+        phaseRef.current = 'idle';
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, []);
+
+  const resetAttempt = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    phaseRef.current = 'idle';
+    firstTimeRef.current = 0;
+  };
+
+  const handleClick = () => {
+    const now = performance.now();
+    const { interval } = DIFFICULTIES[difficulty];
+
+    if (phaseRef.current === 'idle') {
+      firstTimeRef.current = now;
+      phaseRef.current = 'waitingSecond';
+      timerRef.current = setTimeout(() => {
+        setStatus('failure');
+        setCombo(0);
+        resetAttempt();
+      }, interval);
+    } else if (phaseRef.current === 'waitingSecond') {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      const diff = now - firstTimeRef.current;
+      if (diff <= interval) {
+        setLast(diff);
+        setBest((prev) => (prev === null || diff < prev ? diff : prev));
+        setStatus('success');
+        phaseRef.current = 'waitingThird';
+        timerRef.current = setTimeout(() => {
+          setCombo((c) => c + 1);
+          resetAttempt();
+        }, interval);
+      } else {
+        setStatus('failure');
+        setCombo(0);
+        resetAttempt();
+      }
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setStatus('failure');
+      setCombo(0);
+      resetAttempt();
+    }
+  };
+
+  const handleReset = useCallback(() => {
+    setStatus('idle');
+    setLast(null);
+    setBest(null);
+    setCombo(0);
+    resetAttempt();
+  }, []);
+
+  useEffect(() => {
+    handleReset();
+  }, [difficulty, handleReset]);
+
+  if (isMobile) {
+    return <div className="p-10 text-center">PCでお試しください</div>;
+  }
+
+  const { size } = DIFFICULTIES[difficulty];
+  const baseColor =
+    status === 'success' ? 'bg-green-500' : status === 'failure' ? 'bg-red-500' : 'bg-blue-500';
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-10 select-none">
+      <h1 className="text-3xl font-bold">ダブルクリック練習</h1>
+      <p>ターゲットを素早くダブルクリックして練習しましょう。</p>
+
+      <div className="flex gap-2">
+        {(Object.keys(DIFFICULTIES) as Difficulty[]).map((key) => (
+          <button
+            key={key}
+            onClick={() => setDifficulty(key)}
+            className={`px-3 py-1 rounded border ${
+              difficulty === key ? 'bg-gray-200' : ''
+            }`}
+          >
+            {DIFFICULTIES[key].label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        ref={targetRef}
+        onClick={handleClick}
+        draggable={false}
+        className={`${baseColor} rounded-full flex items-center justify-center`}
+        style={{ width: size, height: size }}
+      ></div>
+
+      <div className="text-center">
+        <div>状態: {status === 'success' ? '成功' : status === 'failure' ? '失敗' : '待機中'}</div>
+        <div>直近間隔: {last !== null ? `${Math.round(last)}ms` : '--'}</div>
+        <div>ベスト間隔: {best !== null ? `${Math.round(best)}ms` : '--'}</div>
+        <div>コンボ: {combo}</div>
+      </div>
+
+      <button onClick={handleReset} className="px-4 py-2 border rounded">
+        リセット
+      </button>
+    </div>
+  );
+}
+

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+const practices = [
+  {
+    href: "/practice/click-challenge",
+    title: "10秒クリックチャレンジ",
+    description: "10秒間でできるだけクリックしよう",
+  },
+  {
+    href: "/practice/double-click",
+    title: "ダブルクリック練習",
+    description: "設定時間内に素早く2回クリックしよう",
+  },
+];
+
+export default function PracticeMenu() {
+  return (
+    <div className="p-10 grid gap-4 sm:grid-cols-2">
+      {practices.map((p) => (
+        <Link
+          key={p.href}
+          href={p.href}
+          className="block p-4 border rounded hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <div className="font-bold">{p.title}</div>
+          <p className="text-sm text-gray-600">{p.description}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add double click practice page with difficulty levels and feedback
- track last/best intervals and combo count
- show mobile-only notice

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8faafad148332b3e33ccf1b621ac4