### PR TITLE
feat: redesign home page with responsive menu cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,116 +1,38 @@
-import Image from "next/image";
 import Link from "next/link";
+
+const menus = [
+  {
+    href: "/practice/click-challenge",
+    title: "10秒クリックチャレンジ",
+    description: "10秒間でできるだけクリックしよう",
+  },
+  {
+    href: "/practice/double-click",
+    title: "ダブルクリック練習",
+    description: "設定時間内に素早く2回クリックしよう",
+  },
+];
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Link
-          href="/practice/click-challenge"
-          className="text-blue-600 underline text-lg"
-        >
-          10秒クリックチャレンジ（スコア制）
-        </Link>
-        <Link
-          href="/practice/double-click"
-          className="rounded border border-blue-600 px-4 py-2 text-blue-600 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          ダブルクリック練習へ
-        </Link>
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-12 px-4">
+      <h1 className="text-3xl font-bold text-gray-800 mb-8">練習メニュー</h1>
+      <div className="grid w-full max-w-4xl gap-6 sm:grid-cols-2">
+        {menus.map((menu) => (
+          <Link
+            key={menu.href}
+            href={menu.href}
+            className="flex flex-col justify-between p-6 bg-white rounded-lg shadow hover:shadow-lg transition-shadow border border-gray-100"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+            <div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">{menu.title}</h2>
+              <p className="text-gray-600 text-sm">{menu.description}</p>
+            </div>
+            <span className="mt-4 text-blue-600 text-sm font-medium">開始する →</span>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- overhaul top page into a responsive grid of menu cards for each practice feature
- apply modern Tailwind styling and typography for a clean look

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a9af74e7f483328a52f6c5878fd3e3